### PR TITLE
Add XAdES signing procedure

### DIFF
--- a/hello.pas
+++ b/hello.pas
@@ -1,0 +1,5 @@
+program HelloWorld;
+
+begin
+  Writeln('Hello, World!');
+end.

--- a/sign_example.pas
+++ b/sign_example.pas
@@ -1,0 +1,16 @@
+program SignExample;
+
+{$APPTYPE CONSOLE}
+
+uses
+  SysUtils, SignXAdES;
+
+begin
+  try
+    SignFileXAdES('input.xml', 'signed.xml', 'mycert.pem', 'mykey.pem');
+    Writeln('Document signed successfully.');
+  except
+    on E: Exception do
+      Writeln('Error signing document: ', E.Message);
+  end;
+end.

--- a/signxades.pas
+++ b/signxades.pas
@@ -1,0 +1,33 @@
+unit SignXAdES;
+
+interface
+
+uses
+  SysUtils;
+
+procedure SignFileXAdES(const InputFile, OutputFile, CertFile, KeyFile: string);
+
+implementation
+
+uses
+  // This example assumes existence of an external XAdES signing library.
+  // Replace 'XAdESLib' with the actual unit names provided by your library.
+  XAdESLib;
+
+procedure SignFileXAdES(const InputFile, OutputFile, CertFile, KeyFile: string);
+var
+  Signer: TXAdESSigner;
+begin
+  Signer := TXAdESSigner.Create;
+  try
+    Signer.InputFile := InputFile;
+    Signer.Certificate := CertFile;
+    Signer.PrivateKey := KeyFile;
+    Signer.Sign;
+    Signer.Save(OutputFile);
+  finally
+    Signer.Free;
+  end;
+end;
+
+end.


### PR DESCRIPTION
## Summary
- add a simple `SignXAdES` unit with an example procedure for signing files
- provide `sign_example.pas` program showing usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685e6f1052dc83238b17fd1fbd949162